### PR TITLE
Change link of latest GU version to 1.2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Min RAM to run this mod: (4-)8Gb (!!don't report lag issues if you have less or 
 
 PREVIOUS VERSION: [GITHUB](https://github.com/StarCrusher96/Galaxies-Unbound-A-Stellar-Odyssey/releases/tag/1.1) (!!never install an update over previous version!!)
 
-! LATEST STABLE VERSION OF GU 1.2: [GITHUB](https://github.com/StarCrusher96/Galaxies-Unbound-A-Stellar-Odyssey/releases/tag/1.2)
+! LATEST STABLE VERSION OF GU 1.2: [GITHUB](https://github.com/StarCrusher96/Galaxies-Unbound-A-Stellar-Odyssey/releases/tag/1.2.1)
 
 
 # How to install Galaxies Unbound: A Stellar Odyssey


### PR DESCRIPTION
The link on the README file is still pointing to the 1.2 release which doesn't have downloads anymore. Change the link to the new 1.2.1 release that has the download links and latest fixes.